### PR TITLE
V0.4.6: Fix the initial focusing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 GROUP=io.github.dokar3
 POM_ARTIFACT_ID=chiptextfield
-VERSION_NAME=0.4.5
+VERSION_NAME=0.4.6
 
 POM_NAME=ChipTextField
 POM_DESCRIPTION=Editable chip layout in Jetpack Compose.

--- a/library/src/main/java/com/dokar/chiptextfield/BasicChipTextField.kt
+++ b/library/src/main/java/com/dokar/chiptextfield/BasicChipTextField.kt
@@ -292,7 +292,7 @@ fun <T : Chip> BasicChipTextField(
 ) {
     val scope = rememberCoroutineScope()
 
-    val textFieldFocusRequester = remember { StableHolder(FocusRequester()) }
+    val textFieldFocusRequester = remember { FocusRequester() }
 
     val editable = enabled && !readOnly
 
@@ -312,7 +312,7 @@ fun <T : Chip> BasicChipTextField(
             .filter { it.isEmpty() }
             .collect {
                 if (hasFocusedChipBeforeEmpty.value) {
-                    textFieldFocusRequester.value.requestFocus()
+                    textFieldFocusRequester.requestFocus()
                 }
                 hasFocusedChipBeforeEmpty.value = false
             }
@@ -339,7 +339,7 @@ fun <T : Chip> BasicChipTextField(
                         onTap = {
                             if (!editable) return@detectTapGestures
                             keyboardController?.show()
-                            textFieldFocusRequester.value.requestFocus()
+                            textFieldFocusRequester.requestFocus()
                             state.focusedChip = null
                             // Move cursor to the end
                             val selection = value.text.length
@@ -369,7 +369,7 @@ fun <T : Chip> BasicChipTextField(
                     interactionSource.tryEmit(FocusInteraction.Unfocus(it))
                 },
                 onLoseFocus = {
-                    textFieldFocusRequester.value.requestFocus()
+                    textFieldFocusRequester.requestFocus()
                     state.focusedChip = null
                 },
                 onChipClick = onChipClick,
@@ -541,7 +541,7 @@ private fun <T : Chip> Input(
     textStyle: TextStyle,
     colors: TextFieldColors,
     keyboardOptions: KeyboardOptions,
-    focusRequester: StableHolder<FocusRequester>,
+    focusRequester: FocusRequester,
     interactionSource: MutableInteractionSource,
     onFocusChange: (isFocused: Boolean) -> Unit,
     modifier: Modifier = Modifier,
@@ -567,7 +567,7 @@ private fun <T : Chip> Input(
             }
         },
         modifier = modifier
-            .focusRequester(focusRequester.value)
+            .focusRequester(focusRequester)
             .onFocusChanged { onFocusChange(it.isFocused) }
             .onPreviewKeyEvent {
                 if (it.type == KeyEventType.KeyDown && it.key == Key.Backspace) {

--- a/library/src/main/java/com/dokar/chiptextfield/BasicChipTextField.kt
+++ b/library/src/main/java/com/dokar/chiptextfield/BasicChipTextField.kt
@@ -298,7 +298,7 @@ fun <T : Chip> BasicChipTextField(
 
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    val bringLastIntoViewRequester = remember { BringIntoViewRequester() }
+    val bringLastIntoViewRequester = remember { StableHolder(BringIntoViewRequester()) }
 
     val hasFocusedChipBeforeEmpty = remember { mutableStateOf(false) }
 
@@ -344,7 +344,7 @@ fun <T : Chip> BasicChipTextField(
                             // Move cursor to the end
                             val selection = value.text.length
                             onValueChange(value.copy(selection = TextRange(selection)))
-                            scope.launch { bringLastIntoViewRequester.bringIntoView() }
+                            scope.launch { bringLastIntoViewRequester.value.bringIntoView() }
                         },
                     )
                 },
@@ -388,7 +388,7 @@ fun <T : Chip> BasicChipTextField(
                     if (chip != null) {
                         scope.launch {
                             awaitFrame()
-                            bringLastIntoViewRequester.bringIntoView()
+                            bringLastIntoViewRequester.value.bringIntoView()
                         }
                     }
                     chip
@@ -408,7 +408,7 @@ fun <T : Chip> BasicChipTextField(
                         state.focusedChip = null
                     }
                 },
-                modifier = Modifier.bringIntoViewRequester(bringLastIntoViewRequester),
+                modifier = Modifier.bringIntoViewRequester(bringLastIntoViewRequester.value),
             )
         }
     }
@@ -431,7 +431,7 @@ private fun <T : Chip> Chips(
     chipStyle: ChipStyle,
     chipLeadingIcon: @Composable (chip: T) -> Unit,
     chipTrailingIcon: @Composable (chip: T) -> Unit,
-    bringLastIntoViewRequester: BringIntoViewRequester,
+    bringLastIntoViewRequester: StableHolder<BringIntoViewRequester>,
 ) {
     val chips = state.chips
 
@@ -520,7 +520,7 @@ private fun <T : Chip> Chips(
             chipLeadingIcon = chipLeadingIcon,
             chipTrailingIcon = chipTrailingIcon,
             modifier = if (index == chips.lastIndex) {
-                Modifier.bringIntoViewRequester(bringLastIntoViewRequester)
+                Modifier.bringIntoViewRequester(bringLastIntoViewRequester.value)
             } else {
                 Modifier
             },

--- a/sample/src/main/java/com/dokar/chiptextfield/sample/TextChips.kt
+++ b/sample/src/main/java/com/dokar/chiptextfield/sample/TextChips.kt
@@ -49,16 +49,15 @@ internal fun TextChips(chipFieldStyle: ChipFieldStyle) {
 
 @Composable
 private fun Underline(chipFieldStyle: ChipFieldStyle) {
-    var value by remember { mutableStateOf("Android") }
-    val state = rememberChipTextFieldState(
-        chips = remember { SampleChips.getTextChips() },
-    )
+    var value by remember { mutableStateOf("") }
+    val state = rememberChipTextFieldState(chips = emptyList())
     ChipTextField(
         state = state,
         value = value,
         onValueChange = { value = it },
         onSubmit = ::Chip,
         modifier = Modifier.padding(8.dp),
+        placeholder = { Text("Enter to submit a chip") },
         chipStyle = ChipTextFieldDefaults.chipStyle(
             focusedTextColor = chipFieldStyle.textColor,
             focusedBorderColor = chipFieldStyle.borderColor,


### PR DESCRIPTION
- The text field will no longer request focus initially if no initial chips were passed to `rememberChipTextFieldState()` #74 
- Fix recompositions
- Bump `accompanist-flowlayout` to 0.30.1