### PR TITLE
V0.5.0: Bump Kotlin to 1.9.10 and Compose Compiler to 1.5.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 buildscript {
     ext {
         compose_bom_version = '2023.08.00'
-        compose_compiler_version = '1.5.1'
-        kotlin_version = '1.9.0'
+        compose_compiler_version = '1.5.3'
+        kotlin_version = '1.9.10'
         compile_sdk = 34
         target_sdk = 34
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 GROUP=io.github.dokar3
 POM_ARTIFACT_ID=chiptextfield
-VERSION_NAME=0.4.9
+VERSION_NAME=0.5.0
 
 POM_NAME=ChipTextField
 POM_DESCRIPTION=Editable chip layout in Jetpack Compose.

--- a/library/src/main/java/com/dokar/chiptextfield/BasicChipTextField.kt
+++ b/library/src/main/java/com/dokar/chiptextfield/BasicChipTextField.kt
@@ -611,6 +611,7 @@ private fun <T : Chip> Input(
                     if (value.text.isEmpty() && state.chips.isNotEmpty()) {
                         // Remove previous chip
                         state.removeLastChip()
+                        state.focusTextField()
                         return@onPreviewKeyEvent true
                     }
                 }


### PR DESCRIPTION
- Bump Kotlin to 1.9.10 and Compose Compiler to 1.5.3
- Fix the text field may lose focus after deleting the last chip