### PR TITLE
v0.6.0

### DIFF
--- a/chiptextfield-core/gradle.properties
+++ b/chiptextfield-core/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=chiptextfield-core
+POM_PACKAGING=aar

--- a/chiptextfield-m3/gradle.properties
+++ b/chiptextfield-m3/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=chiptextfield-m3
+POM_PACKAGING=aar

--- a/chiptextfield/gradle.properties
+++ b/chiptextfield/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=chiptextfield
+POM_PACKAGING=aar

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,6 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.github.dokar3
-POM_ARTIFACT_ID=chiptextfield
 VERSION_NAME=0.6.0
 
 POM_NAME=ChipTextField

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 GROUP=io.github.dokar3
 POM_ARTIFACT_ID=chiptextfield
-VERSION_NAME=0.5.0
+VERSION_NAME=0.6.0
 
 POM_NAME=ChipTextField
 POM_DESCRIPTION=Editable chip layout in Jetpack Compose.


### PR DESCRIPTION
## What's Changed
- Add Material 3 support
  ```groovy
  implementation "io.github.dokar3:chiptextfield-m3:latest_version"
  ```
  ```diff
  - import com.dokar.chiptextfield.OutlinedChipTextField
  + import com.dokar.chiptextfield.m3.OutlinedChipTextField
  ```  
  
- Bump Compose to 1.5.1
- Fix the text field focusing